### PR TITLE
fix: purge build/ binaries from git history and add to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
 # Qdrant data
 qdrant_storage/
 
-# Go binaries (local dev only, not the build/ output)
+# Go binaries
 /clawbrain
+build/
 *.dll
 *.so
 *.dylib


### PR DESCRIPTION
## Summary

- Purge all `build/` directory and `build.sh` blobs from git history using `git filter-repo`, shrinking `.git/` from **904 MB to 336 KB**
- Add `build/` to `.gitignore` to prevent accidental re-introduction of compiled binaries

## Context

A pre-commit hook (introduced in `181ed34`) cross-compiled 5 Go binaries (~18 MB each) into `build/` on every commit. Over 19 commits, ~90 versions accumulated in git history (~1,550 MB uncompressed). The binaries were removed from HEAD in `edbd379` but all historical blobs remained, making pushes and clones extremely slow.

The project builds from source inside Docker -- pre-built binaries are not needed.

**Note:** This rewrites all commit hashes. Existing clones will need to re-clone.

Closes #1