### PR TITLE
fix: dedup skips pinned memories (closes #2)

### DIFF
--- a/cmd/clawbrain/main.go
+++ b/cmd/clawbrain/main.go
@@ -280,9 +280,13 @@ func dedupAndDelete(ctx context.Context, s *store.Store, vector []float32) []sto
 		return nil
 	}
 
-	// Delete all old duplicates
+	// Delete all old duplicates, but never delete pinned memories.
 	var deleted []store.Result
 	for _, old := range similar {
+		if pinned, ok := old.Payload["pinned"].(bool); ok && pinned {
+			// Pinned memories are immune to automatic deletion, including dedup.
+			continue
+		}
 		if err := s.Delete(ctx, old.ID); err != nil {
 			// Non-fatal: skip this one, keep trying the rest.
 			continue


### PR DESCRIPTION
## What

`dedupAndDelete` was silently deleting pinned memories when a new, very similar memory was added. Pinned memories should be immune to both `forget` and dedup.

## Why

The dedup loop checked cosine similarity but did not check the `pinned` flag. If a pinned memory scored above the 0.92 threshold against a new entry, it got queued for deletion.

## Change

One-line guard in `dedupAndDelete`: skip any candidate whose `pinned` field is true.

```go
if pinned, ok := old.Payload["pinned"].(bool); ok && pinned {
    continue
}
```

This fix was originally merged before a repo deletion rolled back main. Re-submitting to restore it.

Closes #2