### PR TITLE
feat: clawbrain sync — auto-ingest markdown memory files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,11 @@ jobs:
         ports:
           - 11434:11434
 
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -61,6 +66,10 @@ jobs:
           curl -sf http://localhost:11434/api/embed -d '{"model": "all-minilm", "input": "test"}' > /dev/null \
             || { echo "Ollama embedding failed — model may not be loaded"; exit 1; }
           echo "Ollama embedding model is ready"
+
+          # Verify Redis is reachable
+          nc -z localhost 6379 || { echo "Redis not reachable on port 6379"; exit 1; }
+          echo "Redis is ready"
 
       - name: Build
         run: go build ./...

--- a/Dockerfile.sync
+++ b/Dockerfile.sync
@@ -1,0 +1,12 @@
+FROM golang:1.25 AS builder
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -o /clawbrain ./cmd/clawbrain
+
+FROM alpine:3.21
+COPY --from=builder /clawbrain /usr/local/bin/clawbrain
+COPY sync.sh /usr/local/bin/sync.sh
+RUN chmod +x /usr/local/bin/clawbrain /usr/local/bin/sync.sh
+ENTRYPOINT ["/usr/local/bin/sync.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,13 @@ services:
       - CLAWBRAIN_INTERVAL=3600
     restart: unless-stopped
 
+  redis:
+    image: redis:7-alpine
+    command: redis-server --appendonly yes
+    volumes:
+      - redis_data:/data
+    restart: unless-stopped
+
   clawbrain:
     build:
       context: .
@@ -55,7 +62,32 @@ services:
     environment:
       - CLAWBRAIN_HOST=qdrant
       - CLAWBRAIN_OLLAMA_URL=http://ollama:11434
+      - CLAWBRAIN_REDIS_HOST=redis
+      - CLAWBRAIN_REDIS_PORT=6379
+    restart: unless-stopped
+
+  sync:
+    build:
+      context: .
+      dockerfile: Dockerfile.sync
+    depends_on:
+      qdrant:
+        condition: service_started
+      ollama-pull:
+        condition: service_completed_successfully
+      redis:
+        condition: service_started
+    environment:
+      - CLAWBRAIN_HOST=qdrant
+      - CLAWBRAIN_OLLAMA_URL=http://ollama:11434
+      - CLAWBRAIN_REDIS_HOST=redis
+      - CLAWBRAIN_REDIS_PORT=6379
+      - CLAWBRAIN_WORKSPACE=/workspace
+      - CLAWBRAIN_SYNC_INTERVAL=3600
+    volumes:
+      - ./workspace:/workspace:ro
     restart: unless-stopped
 
 volumes:
   ollama_data:
+  redis_data:

--- a/internal/redis/redis.go
+++ b/internal/redis/redis.go
@@ -1,0 +1,104 @@
+// Package redis provides a minimal Redis client using the RESP protocol.
+// It supports only the commands needed by ClawBrain's sync feature:
+// SET, EXISTS, and SET with EX (TTL). No external dependencies.
+package redis
+
+import (
+	"bufio"
+	"fmt"
+	"net"
+	"strconv"
+	"time"
+)
+
+// Client is a minimal Redis client.
+type Client struct {
+	conn net.Conn
+	rd   *bufio.Reader
+}
+
+// New connects to a Redis server and returns a Client.
+func New(host string, port int) (*Client, error) {
+	addr := net.JoinHostPort(host, fmt.Sprintf("%d", port))
+	conn, err := net.DialTimeout("tcp", addr, 5*time.Second)
+	if err != nil {
+		return nil, fmt.Errorf("connect to redis at %s: %w", addr, err)
+	}
+	return &Client{conn: conn, rd: bufio.NewReader(conn)}, nil
+}
+
+// Close closes the underlying connection.
+func (c *Client) Close() error {
+	return c.conn.Close()
+}
+
+// Ping checks connectivity by sending a PING command.
+func (c *Client) Ping() error {
+	if err := c.sendCommand("PING"); err != nil {
+		return err
+	}
+	_, err := c.readLine()
+	return err
+}
+
+// Set stores a key with a value and no expiry.
+func (c *Client) Set(key, value string) error {
+	if err := c.sendCommand("SET", key, value); err != nil {
+		return err
+	}
+	_, err := c.readLine()
+	return err
+}
+
+// SetWithTTL stores a key with a value and a TTL in seconds.
+func (c *Client) SetWithTTL(key, value string, ttlSeconds int) error {
+	if err := c.sendCommand("SET", key, value, "EX", strconv.Itoa(ttlSeconds)); err != nil {
+		return err
+	}
+	_, err := c.readLine()
+	return err
+}
+
+// Exists returns true if the key exists in Redis.
+func (c *Client) Exists(key string) (bool, error) {
+	if err := c.sendCommand("EXISTS", key); err != nil {
+		return false, err
+	}
+	line, err := c.readLine()
+	if err != nil {
+		return false, err
+	}
+	// RESP integer reply: ":1\r\n" or ":0\r\n"
+	if len(line) >= 2 && line[0] == ':' {
+		return line[1] == '1', nil
+	}
+	return false, fmt.Errorf("unexpected EXISTS reply: %q", line)
+}
+
+// sendCommand writes a RESP array command to the connection.
+func (c *Client) sendCommand(args ...string) error {
+	// RESP array: *<count>\r\n followed by $<len>\r\n<data>\r\n for each arg
+	buf := fmt.Sprintf("*%d\r\n", len(args))
+	for _, arg := range args {
+		buf += fmt.Sprintf("$%d\r\n%s\r\n", len(arg), arg)
+	}
+	_, err := c.conn.Write([]byte(buf))
+	return err
+}
+
+// readLine reads a single RESP line from the connection.
+func (c *Client) readLine() (string, error) {
+	line, err := c.rd.ReadString('\n')
+	if err != nil {
+		return "", err
+	}
+	// Strip trailing \r\n
+	if len(line) >= 2 && line[len(line)-2] == '\r' {
+		line = line[:len(line)-2]
+	}
+	// Check for RESP errors
+	if len(line) > 0 && line[0] == '-' {
+		return "", fmt.Errorf("redis error: %s", line[1:])
+	}
+	return line, nil
+}

--- a/internal/redis/redis_test.go
+++ b/internal/redis/redis_test.go
@@ -1,0 +1,120 @@
+package redis
+
+import (
+	"net"
+	"testing"
+	"time"
+)
+
+func skipIfNoRedis(t *testing.T) {
+	t.Helper()
+	conn, err := net.DialTimeout("tcp", "localhost:6379", 2*time.Second)
+	if err != nil {
+		t.Skipf("Redis not available on localhost:6379, skipping: %v", err)
+	}
+	conn.Close()
+}
+
+func TestPing(t *testing.T) {
+	skipIfNoRedis(t)
+	c, err := New("localhost", 6379)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	if err := c.Ping(); err != nil {
+		t.Fatalf("Ping failed: %v", err)
+	}
+}
+
+func TestSetAndExists(t *testing.T) {
+	skipIfNoRedis(t)
+	c, err := New("localhost", 6379)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	key := "clawbrain_test:set_exists"
+
+	// Clean up
+	c.sendCommand("DEL", key)
+	c.readLine()
+
+	// Key should not exist
+	exists, err := c.Exists(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exists {
+		t.Fatal("expected key to not exist before SET")
+	}
+
+	// Set it
+	if err := c.Set(key, "1"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Should exist now
+	exists, err = c.Exists(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !exists {
+		t.Fatal("expected key to exist after SET")
+	}
+
+	// Clean up
+	c.sendCommand("DEL", key)
+	c.readLine()
+}
+
+func TestSetWithTTL(t *testing.T) {
+	skipIfNoRedis(t)
+	c, err := New("localhost", 6379)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	key := "clawbrain_test:set_ttl"
+
+	// Clean up
+	c.sendCommand("DEL", key)
+	c.readLine()
+
+	// Set with 2-second TTL
+	if err := c.SetWithTTL(key, "1", 2); err != nil {
+		t.Fatal(err)
+	}
+
+	// Should exist immediately
+	exists, err := c.Exists(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !exists {
+		t.Fatal("expected key to exist immediately after SetWithTTL")
+	}
+
+	// Wait for TTL to expire
+	time.Sleep(3 * time.Second)
+
+	// Should be gone
+	exists, err = c.Exists(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exists {
+		t.Fatal("expected key to expire after TTL")
+	}
+}
+
+func TestConnectionError(t *testing.T) {
+	// Connect to a port that's definitely not Redis
+	_, err := New("localhost", 1)
+	if err == nil {
+		t.Fatal("expected connection error to port 1")
+	}
+}

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -1,0 +1,270 @@
+// Package sync provides file-to-memory synchronization for ClawBrain.
+// It reads markdown files, chunks them, and adds new content to ClawBrain
+// while skipping already-ingested content tracked via Redis.
+package sync
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// Default chunking parameters (character-based approximation of tokens).
+// ~1600 chars ≈ ~400 tokens, ~320 chars ≈ ~80 tokens overlap.
+const (
+	DefaultChunkSize    = 1600
+	DefaultChunkOverlap = 320
+)
+
+// redisKeyPrefix is prepended to all sync tracking keys in Redis.
+const redisKeyPrefix = "sync:"
+
+// memoryMDTTL is the TTL for MEMORY.md entries in Redis (7 days).
+const memoryMDTTL = 7 * 24 * 60 * 60 // 604800 seconds
+
+// datePattern matches filenames containing YYYY-MM-DD.
+var datePattern = regexp.MustCompile(`\d{4}-\d{2}-\d{2}`)
+
+// FileResult holds the sync outcome for a single file.
+type FileResult struct {
+	File    string `json:"file"`
+	Added   int    `json:"added"`
+	Skipped int    `json:"skipped"`
+	Reason  string `json:"reason,omitempty"`
+}
+
+// Chunk splits text into overlapping chunks of approximately the given size.
+// It prefers splitting at paragraph boundaries (double newline), then
+// sentence boundaries, then falls back to hard character splits.
+func Chunk(text string, size, overlap int) []string {
+	text = strings.TrimSpace(text)
+	if len(text) == 0 {
+		return nil
+	}
+	if len(text) <= size {
+		return []string{text}
+	}
+
+	var chunks []string
+	start := 0
+	for start < len(text) {
+		prevStart := start
+		end := start + size
+		if end >= len(text) {
+			chunks = append(chunks, strings.TrimSpace(text[start:]))
+			break
+		}
+
+		// Try to find a paragraph boundary (double newline) near the end
+		splitAt := findSplit(text, start, end, "\n\n")
+		if splitAt == -1 {
+			// Try sentence boundary (. followed by space or newline)
+			splitAt = findSentenceSplit(text, start, end)
+		}
+		if splitAt == -1 {
+			// Try single newline
+			splitAt = findSplit(text, start, end, "\n")
+		}
+		if splitAt == -1 {
+			// Hard split at size
+			splitAt = end
+		}
+
+		chunk := strings.TrimSpace(text[start:splitAt])
+		if chunk != "" {
+			chunks = append(chunks, chunk)
+		}
+
+		// Next chunk starts with overlap from the end of the current chunk
+		start = splitAt - overlap
+		if start < 0 {
+			start = 0
+		}
+		// Prevent infinite loop: always advance past the previous start
+		if start <= prevStart {
+			start = prevStart + size
+		}
+	}
+
+	return chunks
+}
+
+// findSplit looks for the last occurrence of sep in text[start:end],
+// preferring a split in the last 25% of the window to maximize chunk size.
+// Returns the position right after the separator, or -1 if not found.
+func findSplit(text string, start, end int, sep string) int {
+	// Search in the last 25% of the chunk for a natural break
+	searchFrom := start + (end-start)*3/4
+	window := text[searchFrom:end]
+	idx := strings.LastIndex(window, sep)
+	if idx != -1 {
+		return searchFrom + idx + len(sep)
+	}
+	return -1
+}
+
+// findSentenceSplit looks for the last sentence-ending punctuation
+// followed by whitespace in the last 25% of the chunk.
+func findSentenceSplit(text string, start, end int) int {
+	searchFrom := start + (end-start)*3/4
+	window := text[searchFrom:end]
+	// Look for ". " or ".\n" or "! " or "? " patterns
+	best := -1
+	for i := len(window) - 2; i >= 0; i-- {
+		if (window[i] == '.' || window[i] == '!' || window[i] == '?') &&
+			i+1 < len(window) && (window[i+1] == ' ' || window[i+1] == '\n') {
+			best = searchFrom + i + 1
+			break
+		}
+	}
+	return best
+}
+
+// NormalizeText normalizes text for consistent comparison:
+// trims outer whitespace and collapses runs of 3+ newlines into 2
+// (preserving paragraph breaks). Collapses runs of spaces/tabs on
+// the same line into a single space. Newlines are preserved so that
+// markdown structure (headings, paragraphs) is not lost -- this
+// matters for embedding quality.
+func NormalizeText(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+
+	// Collapse runs of 3+ newlines into double newline (paragraph break)
+	var b strings.Builder
+	newlineRun := 0
+	spaceRun := false
+	for _, r := range s {
+		if r == '\n' {
+			newlineRun++
+			spaceRun = false
+			if newlineRun <= 2 {
+				b.WriteRune('\n')
+			}
+		} else if r == ' ' || r == '\t' {
+			newlineRun = 0
+			if !spaceRun {
+				b.WriteRune(' ')
+				spaceRun = true
+			}
+		} else {
+			newlineRun = 0
+			spaceRun = false
+			b.WriteRune(r)
+		}
+	}
+	return strings.TrimSpace(b.String())
+}
+
+// RedisKey returns the Redis key for tracking a file's sync state.
+func RedisKey(filePath string) string {
+	return redisKeyPrefix + filePath
+}
+
+// MemoryMDTTLSeconds returns the TTL in seconds for MEMORY.md entries.
+func MemoryMDTTLSeconds() int {
+	return memoryMDTTL
+}
+
+// IsMemoryMD returns true if the filename (case-insensitive) is memory.md.
+func IsMemoryMD(filePath string) bool {
+	base := filepath.Base(filePath)
+	return strings.EqualFold(base, "memory.md")
+}
+
+// IsTodayDailyFile returns true if the filename contains today's date (YYYY-MM-DD).
+// Today's daily file is still being written and should be skipped.
+func IsTodayDailyFile(filePath string) bool {
+	base := filepath.Base(filePath)
+	match := datePattern.FindString(base)
+	if match == "" {
+		return false
+	}
+	today := time.Now().Format("2006-01-02")
+	return match == today
+}
+
+// DiscoverFiles finds markdown files to sync based on explicit paths and/or
+// the default agent memory layout. Returns a deduplicated list of absolute paths.
+func DiscoverFiles(basePath string, files []string, dirs []string) ([]string, error) {
+	seen := make(map[string]bool)
+	var result []string
+
+	addFile := func(path string) error {
+		abs, err := filepath.Abs(path)
+		if err != nil {
+			return err
+		}
+		if seen[abs] {
+			return nil
+		}
+		// Verify it exists and is a file
+		info, err := os.Stat(abs)
+		if err != nil {
+			// Skip missing files silently
+			return nil
+		}
+		if info.IsDir() {
+			return nil
+		}
+		seen[abs] = true
+		result = append(result, abs)
+		return nil
+	}
+
+	// Explicit files
+	for _, f := range files {
+		if err := addFile(f); err != nil {
+			return nil, err
+		}
+	}
+
+	// Explicit directories: glob for *.md
+	for _, d := range dirs {
+		matches, err := filepath.Glob(filepath.Join(d, "*.md"))
+		if err != nil {
+			return nil, fmt.Errorf("glob %s: %w", d, err)
+		}
+		for _, m := range matches {
+			if err := addFile(m); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	// Default discovery if no explicit paths given
+	if len(files) == 0 && len(dirs) == 0 {
+		// Look for MEMORY.md in basePath. Try the canonical name first,
+		// then the lowercase variant. Only add the first one found to
+		// avoid duplicates on case-insensitive filesystems (macOS).
+		for _, name := range []string{"MEMORY.md", "memory.md"} {
+			p := filepath.Join(basePath, name)
+			if _, err := os.Stat(p); err == nil {
+				if err := addFile(p); err != nil {
+					return nil, err
+				}
+				break // only add the first match
+			}
+		}
+		// Look for memory/*.md
+		memDir := filepath.Join(basePath, "memory")
+		if info, err := os.Stat(memDir); err == nil && info.IsDir() {
+			matches, err := filepath.Glob(filepath.Join(memDir, "*.md"))
+			if err != nil {
+				return nil, fmt.Errorf("glob memory dir: %w", err)
+			}
+			for _, m := range matches {
+				if err := addFile(m); err != nil {
+					return nil, err
+				}
+			}
+		}
+	}
+
+	return result, nil
+}

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -1,0 +1,267 @@
+package sync
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestChunk_SmallText(t *testing.T) {
+	text := "This is a short text."
+	chunks := Chunk(text, 1600, 320)
+	if len(chunks) != 1 {
+		t.Fatalf("expected 1 chunk, got %d", len(chunks))
+	}
+	if chunks[0] != text {
+		t.Errorf("expected %q, got %q", text, chunks[0])
+	}
+}
+
+func TestChunk_EmptyText(t *testing.T) {
+	chunks := Chunk("", 1600, 320)
+	if len(chunks) != 0 {
+		t.Fatalf("expected 0 chunks for empty text, got %d", len(chunks))
+	}
+}
+
+func TestChunk_WhitespaceOnly(t *testing.T) {
+	chunks := Chunk("   \n\n  \t  ", 1600, 320)
+	if len(chunks) != 0 {
+		t.Fatalf("expected 0 chunks for whitespace-only text, got %d", len(chunks))
+	}
+}
+
+func TestChunk_ExactSize(t *testing.T) {
+	// Text exactly at chunk size should return 1 chunk
+	text := strings.Repeat("a", 1600)
+	chunks := Chunk(text, 1600, 320)
+	if len(chunks) != 1 {
+		t.Fatalf("expected 1 chunk, got %d", len(chunks))
+	}
+}
+
+func TestChunk_SplitsLargeText(t *testing.T) {
+	// Build text with paragraph breaks
+	paragraphs := make([]string, 10)
+	for i := range paragraphs {
+		paragraphs[i] = strings.Repeat("word ", 80) // ~400 chars each
+	}
+	text := strings.Join(paragraphs, "\n\n")
+
+	chunks := Chunk(text, 1600, 320)
+	if len(chunks) < 2 {
+		t.Fatalf("expected at least 2 chunks, got %d", len(chunks))
+	}
+
+	// All chunks should be non-empty
+	for i, chunk := range chunks {
+		if strings.TrimSpace(chunk) == "" {
+			t.Errorf("chunk %d is empty", i)
+		}
+	}
+
+	// No chunk should exceed size by more than a reasonable margin
+	// (exact boundary might vary due to paragraph-aware splitting)
+	for i, chunk := range chunks {
+		if len(chunk) > 2000 { // generous margin
+			t.Errorf("chunk %d is too large: %d chars", i, len(chunk))
+		}
+	}
+}
+
+func TestChunk_OverlapPresent(t *testing.T) {
+	// Create text that will produce multiple chunks
+	text := strings.Repeat("The quick brown fox jumps over the lazy dog. ", 100)
+	chunks := Chunk(text, 400, 100)
+
+	if len(chunks) < 2 {
+		t.Fatalf("expected at least 2 chunks, got %d", len(chunks))
+	}
+
+	// Check that consecutive chunks have overlapping content
+	for i := 1; i < len(chunks); i++ {
+		prev := chunks[i-1]
+		curr := chunks[i]
+		// The end of the previous chunk should share some content with
+		// the beginning of the current chunk (overlap)
+		prevEnd := prev[len(prev)/2:] // second half of prev
+		if !hasOverlap(prevEnd, curr) {
+			t.Errorf("chunks %d and %d appear to have no overlap", i-1, i)
+		}
+	}
+}
+
+func hasOverlap(a, b string) bool {
+	// Check if any substring of reasonable length from a appears at the start of b
+	minOverlap := 20
+	if len(a) < minOverlap || len(b) < minOverlap {
+		return true // too small to check meaningfully
+	}
+	for i := 0; i <= len(a)-minOverlap; i++ {
+		sub := a[i : i+minOverlap]
+		if strings.Contains(b[:min(len(b), len(a))], sub) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestNormalizeText(t *testing.T) {
+	tests := []struct {
+		input, want string
+	}{
+		{"  hello  world  ", "hello world"},
+		{"line1\n\nline2", "line1\n\nline2"},     // paragraph break preserved
+		{"line1\n\n\n\nline2", "line1\n\nline2"}, // excessive newlines collapsed to 2
+		{"tabs\t\there", "tabs here"},            // tabs collapsed
+		{"already normal", "already normal"},
+		{"  ", ""},
+		{"# Title\n\nParagraph", "# Title\n\nParagraph"}, // markdown structure preserved
+		{"a\nb\nc", "a\nb\nc"},                           // single newlines preserved
+	}
+	for _, tt := range tests {
+		got := NormalizeText(tt.input)
+		if got != tt.want {
+			t.Errorf("NormalizeText(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestIsMemoryMD(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{"MEMORY.md", true},
+		{"memory.md", true},
+		{"Memory.md", true},
+		{"/path/to/MEMORY.md", true},
+		{"/path/to/memory.md", true},
+		{"memory/2024-01-15.md", false},
+		{"notes.md", false},
+		{"MEMORY.txt", false},
+	}
+	for _, tt := range tests {
+		got := IsMemoryMD(tt.path)
+		if got != tt.want {
+			t.Errorf("IsMemoryMD(%q) = %v, want %v", tt.path, got, tt.want)
+		}
+	}
+}
+
+func TestIsTodayDailyFile(t *testing.T) {
+	today := time.Now().Format("2006-01-02")
+	yesterday := time.Now().AddDate(0, 0, -1).Format("2006-01-02")
+
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{today + ".md", true},
+		{"memory/" + today + ".md", true},
+		{yesterday + ".md", false},
+		{"memory/" + yesterday + ".md", false},
+		{"MEMORY.md", false},
+		{"notes.md", false},
+		{"2024-13-45.md", false}, // invalid date still matches regex, but not today
+	}
+	for _, tt := range tests {
+		got := IsTodayDailyFile(tt.path)
+		if got != tt.want {
+			t.Errorf("IsTodayDailyFile(%q) = %v, want %v", tt.path, got, tt.want)
+		}
+	}
+}
+
+func TestRedisKey(t *testing.T) {
+	got := RedisKey("/workspace/MEMORY.md")
+	want := "sync:/workspace/MEMORY.md"
+	if got != want {
+		t.Errorf("RedisKey() = %q, want %q", got, want)
+	}
+}
+
+func TestDiscoverFiles_ExplicitFile(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "test.md")
+	os.WriteFile(f, []byte("hello"), 0644)
+
+	files, err := DiscoverFiles(dir, []string{f}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 1 {
+		t.Fatalf("expected 1 file, got %d", len(files))
+	}
+}
+
+func TestDiscoverFiles_ExplicitDir(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "one.md"), []byte("a"), 0644)
+	os.WriteFile(filepath.Join(dir, "two.md"), []byte("b"), 0644)
+	os.WriteFile(filepath.Join(dir, "three.txt"), []byte("c"), 0644) // not .md
+
+	files, err := DiscoverFiles(dir, nil, []string{dir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 2 {
+		t.Fatalf("expected 2 .md files, got %d: %v", len(files), files)
+	}
+}
+
+func TestDiscoverFiles_DefaultLayout(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "MEMORY.md"), []byte("curated"), 0644)
+	memDir := filepath.Join(dir, "memory")
+	os.Mkdir(memDir, 0755)
+	os.WriteFile(filepath.Join(memDir, "2024-01-15.md"), []byte("daily"), 0644)
+	os.WriteFile(filepath.Join(memDir, "2024-01-16.md"), []byte("daily"), 0644)
+
+	files, err := DiscoverFiles(dir, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 3 {
+		t.Fatalf("expected 3 files (MEMORY.md + 2 daily), got %d: %v", len(files), files)
+	}
+}
+
+func TestDiscoverFiles_NoDuplicates(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "test.md")
+	os.WriteFile(f, []byte("hello"), 0644)
+
+	// Pass the same file twice
+	files, err := DiscoverFiles(dir, []string{f, f}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 1 {
+		t.Fatalf("expected 1 file (deduped), got %d", len(files))
+	}
+}
+
+func TestDiscoverFiles_MissingFilesSilentlySkipped(t *testing.T) {
+	dir := t.TempDir()
+	files, err := DiscoverFiles(dir, []string{"/nonexistent/file.md"}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 0 {
+		t.Fatalf("expected 0 files, got %d", len(files))
+	}
+}
+
+func TestDiscoverFiles_EmptyResult(t *testing.T) {
+	dir := t.TempDir()
+	files, err := DiscoverFiles(dir, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 0 {
+		t.Fatalf("expected 0 files, got %d", len(files))
+	}
+}

--- a/sync.sh
+++ b/sync.sh
@@ -1,0 +1,71 @@
+#!/bin/sh
+# sync.sh — Automatic markdown memory ingestion sidecar.
+#
+# Runs in a loop: syncs markdown files into ClawBrain, sleeps.
+# New files are chunked, embedded, and stored as memories.
+# Already-processed files are tracked in Redis and skipped.
+#
+# Environment variables:
+#   CLAWBRAIN_HOST          Qdrant host (default: qdrant)
+#   CLAWBRAIN_PORT          Qdrant gRPC port (default: 6334)
+#   CLAWBRAIN_OLLAMA_URL    Ollama URL (default: http://ollama:11434)
+#   CLAWBRAIN_REDIS_HOST    Redis host (default: redis)
+#   CLAWBRAIN_REDIS_PORT    Redis port (default: 6379)
+#   CLAWBRAIN_WORKSPACE     Base path for file discovery (default: /workspace)
+#   CLAWBRAIN_SYNC_INTERVAL Sleep between cycles in seconds (default: 3600 = 1 hour)
+
+set -e
+
+CLAWBRAIN="/usr/local/bin/clawbrain"
+HOST="${CLAWBRAIN_HOST:-qdrant}"
+PORT="${CLAWBRAIN_PORT:-6334}"
+OLLAMA_URL="${CLAWBRAIN_OLLAMA_URL:-http://ollama:11434}"
+REDIS_HOST="${CLAWBRAIN_REDIS_HOST:-redis}"
+REDIS_PORT="${CLAWBRAIN_REDIS_PORT:-6379}"
+WORKSPACE="${CLAWBRAIN_WORKSPACE:-/workspace}"
+INTERVAL="${CLAWBRAIN_SYNC_INTERVAL:-3600}"
+
+log() {
+    echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] $*"
+}
+
+# Wait for Qdrant to be reachable.
+log "Waiting for Qdrant at ${HOST}:${PORT}..."
+while ! nc -z "${HOST}" "${PORT}" 2>/dev/null; do
+    sleep 2
+done
+log "Qdrant is up."
+
+# Wait for Ollama to be reachable (sync needs embeddings).
+OLLAMA_HOST_PORT=$(echo "${OLLAMA_URL}" | sed 's|http://||' | sed 's|https://||')
+log "Waiting for Ollama at ${OLLAMA_HOST_PORT}..."
+while ! nc -z $(echo "${OLLAMA_HOST_PORT}" | tr ':' ' ') 2>/dev/null; do
+    sleep 2
+done
+log "Ollama is up."
+
+# Wait for Redis to be reachable.
+log "Waiting for Redis at ${REDIS_HOST}:${REDIS_PORT}..."
+while ! nc -z "${REDIS_HOST}" "${REDIS_PORT}" 2>/dev/null; do
+    sleep 2
+done
+log "Redis is up."
+
+log "Starting sync loop: workspace=${WORKSPACE}, interval=${INTERVAL}s"
+
+while true; do
+    RESULT=$("${CLAWBRAIN}" \
+        --host "${HOST}" \
+        --port "${PORT}" \
+        --ollama-url "${OLLAMA_URL}" \
+        --redis-host "${REDIS_HOST}" \
+        --redis-port "${REDIS_PORT}" \
+        sync --base "${WORKSPACE}" 2>/dev/null) || true
+
+    ADDED=$(echo "${RESULT}" | grep -o '"added":[0-9]*' | grep -o '[0-9]*')
+    if [ "${ADDED}" != "0" ] && [ -n "${ADDED}" ]; then
+        log "Synced ${ADDED} new chunks"
+    fi
+
+    sleep "${INTERVAL}"
+done


### PR DESCRIPTION
## Summary

Implements `clawbrain sync` (issue #5) — a CLI command and Docker sidecar that automatically ingests markdown memory files into ClawBrain.

- Reads markdown files, chunks them (~1600 chars with overlap), embeds via Ollama, stores as memories
- Tracks processed files in Redis so repeated runs skip already-ingested content
- Runs as a Docker sidecar every hour alongside the existing forget sidecar

## File handling

| File type | Behavior |
|---|---|
| `memory/2026-02-20.md` (past daily) | Ingested once, tracked permanently in Redis |
| `memory/2026-02-22.md` (today) | Skipped — still being written |
| `MEMORY.md` (case-insensitive) | Tracked with 7-day TTL, re-processed weekly |
| Other `.md` files | Ingested once, tracked permanently |

## New components

- **`internal/redis/`** — Minimal RESP protocol Redis client. Zero external dependencies. Supports `Set`, `SetWithTTL`, `Exists`, `Ping`.
- **`internal/sync/`** — Chunking with paragraph/sentence-aware splitting, file discovery (explicit paths or default `MEMORY.md` + `memory/*.md` layout), today-detection for daily files, MEMORY.md detection.
- **`cmd/clawbrain/main.go`** — New `sync` subcommand with `--file`, `--dir`, `--base` flags and `--redis-host`/`--redis-port` global flags.
- **`sync.sh` + `Dockerfile.sync`** — Sidecar loop (same pattern as forget.sh). Waits for Qdrant + Ollama + Redis, runs sync every `CLAWBRAIN_SYNC_INTERVAL` seconds.
- **`docker-compose.yml`** — Adds `redis` (redis:7-alpine with AOF persistence) and `sync` sidecar services.

## Safety

- Files are only marked as synced in Redis when at least one chunk is successfully stored. Transient Ollama failures do not permanently mark files as done.
- Sync uses a 10-minute context timeout (vs 30s for other commands) since it is a batch operation.
- Chunk splitting guards against infinite loops with pathological parameters.
- `NormalizeText` preserves markdown structure (paragraph breaks, newlines) for better embedding quality.

## Tests

22 new tests across all packages:
- `internal/sync/` — 16 unit tests: chunking, normalization, file discovery, date detection, MEMORY.md detection
- `internal/redis/` — 4 integration tests: ping, set/exists, TTL expiry, connection error
- `cmd/clawbrain/` — 6 CLI integration tests: single file sync, dedup skip on re-run, empty file, directory sync, no files, today's daily file skip

CI updated with Redis service.

Closes #5