### PR TITLE
fix: add exec timeout to plugin, add .dockerignore, log sync errors

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+qdrant_storage/
+workspace/
+openclaw-plugin/
+.git/
+.github/
+*.md
+LICENSE
+
+# Build artifacts (matches .gitignore)
+/clawbrain
+build/
+*.test
+*.out
+*.dll
+*.so
+*.dylib

--- a/cmd/clawbrain/main.go
+++ b/cmd/clawbrain/main.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"log"
 	"os"
 	"strings"
 	"time"
@@ -518,6 +519,7 @@ func runSync(args []string) {
 			vector, err := oc.Embed(ctx, globalModel, normalized)
 			if err != nil {
 				// Non-fatal per chunk: log and continue
+				log.Printf("sync: embed failed for %s chunk %d: %v", filePath, i, err)
 				continue
 			}
 
@@ -538,6 +540,7 @@ func runSync(args []string) {
 
 			_, err = s.Add(ctx, "", vector, payload)
 			if err != nil {
+				log.Printf("sync: store failed for %s chunk %d: %v", filePath, i, err)
 				continue
 			}
 			added++


### PR DESCRIPTION
## Summary

- Add 60s execution timeout to the OpenClaw plugin's `execFile` call, preventing the Gateway from hanging indefinitely when Docker/Ollama/Qdrant is unresponsive — the primary cause of repeated watchdog restarts (closes #10)
- Add `.dockerignore` to exclude `qdrant_storage/`, `workspace/`, `openclaw-plugin/`, `.git/`, and build artifacts from Docker build context — without this, builds transferred multi-GB of unnecessary data and could fail to complete (closes #11)
- Add `log.Printf` for silently skipped embedding and store errors during sync so failures are visible in container logs (closes #12)
- Include stderr in plugin error messages so the agent gets diagnostic context instead of opaque failures (closes #13)

## Changes

| File | What changed |
|------|-------------|
| `openclaw-plugin/index.ts` | Added `timeout: 60_000` to `execFile` options; stderr now included in error messages |
| `.dockerignore` | New file — excludes storage, workspace, plugin, git, and build artifacts from Docker context |
| `cmd/clawbrain/main.go` | Added `log.Printf` for embed and store failures during sync; added `"log"` import |

## Verification

- `go vet ./...` — clean
- `go build ./...` — clean
- `npm run typecheck` (plugin) — clean
- `docker compose up -d --build` — all 7 containers running, `clawbrain check` returns OK
- Docker build context dropped from 10+ GB to ~19 MB